### PR TITLE
[feature] Add notification badge count

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -44,6 +44,8 @@ PODS:
     - GoogleUtilities/UserDefaults (~> 6.5)
     - Protobuf (>= 3.9.2, ~> 3.9)
   - Flutter (1.0.0)
+  - flutter_app_badger (0.0.1):
+    - Flutter
   - flutter_local_notifications (0.0.1):
     - Flutter
   - GoogleDataTransport (7.4.0):
@@ -77,6 +79,7 @@ DEPENDENCIES:
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
   - firebase_messaging (from `.symlinks/plugins/firebase_messaging/ios`)
   - Flutter (from `Flutter`)
+  - flutter_app_badger (from `.symlinks/plugins/flutter_app_badger/ios`)
   - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
 
 SPEC REPOS:
@@ -102,6 +105,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/firebase_messaging/ios"
   Flutter:
     :path: Flutter
+  flutter_app_badger:
+    :path: ".symlinks/plugins/flutter_app_badger/ios"
   flutter_local_notifications:
     :path: ".symlinks/plugins/flutter_local_notifications/ios"
 
@@ -117,6 +122,7 @@ SPEC CHECKSUMS:
   FirebaseInstanceID: cef67c4967c7cecb56ea65d8acbb4834825c587b
   FirebaseMessaging: 29543feb343b09546ab3aa04d008ee8595b43c44
   Flutter: 0e3d915762c693b495b44d77113d4970485de6ec
+  flutter_app_badger: 65de4d6f0c34a891df49e6cfb8a1c0496426fa68
   flutter_local_notifications: 0c0b1ae97e741e1521e4c1629a459d04b9aec743
   GoogleDataTransport: b7f406340a291370045a270c599e53c6fa6ec20f
   GoogleUtilities: 7f2f5a07f888cdb145101d6042bc4422f57e70b3

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,16 +3,17 @@ import 'dart:io';
 
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_app_badger/flutter_app_badger.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_second_brain/models/fcm_notification.model.dart';
 
 int _notificationId = 1000;
 
-int getForegroundNotificationId() {
-  return _notificationId++;
-}
+int _notificationCount = 0;
 
 int getBackgroundNotificationId() {
+  _notificationCount += 1;
+  FlutterAppBadger.updateBadgeCount(_notificationCount);
   return _notificationId++;
 }
 
@@ -92,19 +93,21 @@ class _MyHomePageState extends State<MyHomePage> {
   IOSInitializationSettings _iosInitializationSettings;
   InitializationSettings _initializationSettings;
   NotificationDetails _notificationDetails;
-  int _notificationId;
+  int _foregroundNotificationCount;
+  int _foregroundNotificationId;
 
   @override
   void initState() {
-    _notificationId = 0;
+    _foregroundNotificationCount = 0;
+    _foregroundNotificationId = 0;
     _firebaseMessaging = FirebaseMessaging();
     _localNotifications = FlutterLocalNotificationsPlugin();
     _androidInitializationSettings =
         AndroidInitializationSettings('@drawable/notification_icon');
     _iosInitializationSettings = IOSInitializationSettings(
-      requestSoundPermission: false,
-      requestBadgePermission: false,
-      requestAlertPermission: false,
+      requestSoundPermission: true,
+      requestBadgePermission: true,
+      requestAlertPermission: true,
       onDidReceiveLocalNotification: null,
     );
     _initializationSettings = InitializationSettings(
@@ -160,6 +163,8 @@ class _MyHomePageState extends State<MyHomePage> {
 
   _showNotifications(message) {
     if (message.containsKey('aps')) {
+      FlutterAppBadger.updateBadgeCount(_foregroundNotificationCount++);
+
       final p = FCMNotification.fromJson(json.decode(json.encode(message)));
       _localNotifications.show(
         _getNotificationId(),
@@ -181,7 +186,7 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 
   int _getNotificationId() {
-    return _notificationId++;
+    return _foregroundNotificationId++;
   }
 
   @override

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -97,6 +97,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_app_badger:
+    dependency: "direct main"
+    description:
+      name: flutter_app_badger
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.2"
   flutter_local_notifications:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   # Firebase
   firebase_messaging: ^7.0.3
   flutter_local_notifications: ^3.0.0
+  flutter_app_badger: ^1.1.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Badge count change happens in two conditions:
1. When app is killed (not running), add a "badge" parameter in the notification payload.

Payload
```
{
    "to": "fcm-token",
    "priority": "high",
    "notification": {
        "title": "Title",
        "body": "First Notification",
        "text": "Text",
        "badge": 24,
        "sound": "default"
    }
}
```

2. A handy plugin called [flutter_app_badger](https://pub.dev/packages/flutter_app_badger) works fine for showing notification count when app is in foreground.

Usage
```
FlutterAppBadger.updateBadgeCount(_notificationCount);
```